### PR TITLE
Fix usage of code coverage checker in project

### DIFF
--- a/bin/code-coverage-checker.php
+++ b/bin/code-coverage-checker.php
@@ -22,9 +22,17 @@ foreach ($autoloaderFiles as $autoloaderFile) {
 
     $loader = require $autoloaderFile;
 
-    $phpunitBridgeDirectory = dirname(realpath($autoloaderFile)) . '/bin/.phpunit';
+    
+    $phpunitBridgeDirectories = [
+        dirname(realpath($autoloaderFile)) . '/bin/.phpunit',
+        dirname(dirname(realpath($autoloaderFile))) . '/bin/.phpunit',
+    ];
 
-    if (is_dir($phpunitBridgeDirectory)) {
+    foreach ($phpunitBridgeDirectories as $phpunitBridgeDirectory) {
+        if (!is_dir($phpunitBridgeDirectory)) {
+            continue;
+        }
+        
         $files = scandir($phpunitBridgeDirectory);
 
         foreach ($files as $file) {
@@ -36,6 +44,8 @@ foreach ($autoloaderFiles as $autoloaderFile) {
                 && file_exists($phpunitAutoloader)
             ) {
                 require $phpunitAutoloader;
+                
+                break 2;
             }
         }
     }

--- a/bin/code-coverage-checker.php
+++ b/bin/code-coverage-checker.php
@@ -103,7 +103,7 @@ foreach ($paths as $path) {
 
 $message = sprintf(
     'Line Coverage for all included files: %.2F%% (%d/%d).',
-    $totalCoveredLines / $totalExecutableLines * 100,
+    $totalExecutableLines ? $totalCoveredLines / $totalExecutableLines * 100 : 100,
     $totalCoveredLines,
     $totalExecutableLines
 );


### PR DESCRIPTION
The symfony phpunit bridge is currently only detected in `vendor/bin/.phpunit` but it should also be detected when stored directly in the `bin/.phpunit` directory.